### PR TITLE
Txt2Tags writer: export writeTxt2Tags from Text.Pandoc.Writers

### DIFF
--- a/src/Text/Pandoc/Writers.hs
+++ b/src/Text/Pandoc/Writers.hs
@@ -75,6 +75,7 @@ module Text.Pandoc.Writers
     , writeTEI
     , writeTexinfo
     , writeTextile
+    , writeTxt2Tags
     , writeTypst
     , writeXML
     , writeXWiki


### PR DESCRIPTION
Add `writeTxt2Tags` to the export list so it is accessible via the `Text.Pandoc` module, fixing a compilation error in tests.